### PR TITLE
로고 중앙정렬

### DIFF
--- a/src/app/main_navbar/main_navbar.module.scss
+++ b/src/app/main_navbar/main_navbar.module.scss
@@ -25,6 +25,7 @@
             font-size: var(--navbar-height);
             font-family: 'Jeju Gothic', sans-serif;
             font-weight: 600;
+            margin-top: 3px;
         }
         
         .menu {


### PR DESCRIPTION
로고가 중앙에서 약간 벗어나있길래 3px 밑으로 내림

## Before
![Screenshot 2023-10-02 at 21-26-52 알고모여](https://github.com/cau-overchaos/frontend/assets/12497886/994c3648-554c-459f-a0e4-1f9eace5b6c2)


## After
![Screenshot 2023-10-02 at 21-26-38 알고모여](https://github.com/cau-overchaos/frontend/assets/12497886/c0619b43-b490-4c63-93b3-7abfb6e2e5f1)