### PR TITLE
Fix solvedac wrong tier icon bug

### DIFF
--- a/src/app/study/[studyId]/assignments/solved_ac_tier.tsx
+++ b/src/app/study/[studyId]/assignments/solved_ac_tier.tsx
@@ -24,6 +24,7 @@ export default function SolvedAcTier(props: Props) {
   } else {
     level = props.level % 5;
     if (level == 0) level = 5;
+    level = 6 - level;
   }
 
   if (1 <= props.level && props.level <= 5) {


### PR DESCRIPTION
solved.ac 티어 아이콘에서 숫자가 거꾸로 표시되는 버그 수정

| 수정 전 | 수정 후 |
|---------|---------|
|    1    |    5    |
|    2    |    4    |
|    3    |    3    |
|    4    |    2    |
|    5    |    1    |
